### PR TITLE
Main site switchover refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Theme that is built to fetch alert data from Roam Secure (or some other external source), create editable post data in WordPress, and generate a new feed for use by ucf.edu.
 
 ## Required Plugins
-(none)
+* Redirection
 
 ## Installation Requirements
 * For automatic feed retrieval from Roam Secure, set up a cron job to run `jobs/check-roam-secure.php` at a regular interval.  The "Enable automated retrieval of alerts" theme option will not work without this cron job set up.

--- a/functions.php
+++ b/functions.php
@@ -173,41 +173,29 @@ function get_theme_option($key) {
 
 
 /**
- * Update the Main Site's home page to use the alert site's content.
- * Setting $activate to false will restore the Main Site to display
- * latest posts (which returns the correct home.php template.)
+ * Update the Main Site to redirect using the Redirection plugin group defined
+ * in theme options.
+ * Setting $activate to false will deactivate the Redirection group.
  **/
-function switchout_main_site_homepg($activate=true) {
+function switchout_main_site_homepg( $activate=true ) {
 	$errors = new WP_Error();
 
-	$main_site_id = intval(get_theme_option('main_site_id'));
-	$main_site_alertpg_id = intval(get_theme_option('main_site_alertpg_id'));
+	$main_site_id          = intval( get_theme_option( 'main_site_id' ) );
+	$main_site_rd_group_id = intval( get_theme_option( 'main_site_rd_group_id' ) );
 
-	switch_to_blog($main_site_id);
+	switch_to_blog( $main_site_id );
 
-	// Set the home page
-	if ($activate == true) {
-		$last_page_on_front = get_option( 'page_on_front' );
-		$last_show_on_front = get_option( 'show_on_front' );
+	$main_site_rd_group = Red_Group::get( $main_site_rd_group_id );
 
-		set_transient( 'last_page_on_front', $last_page_on_front );
-		set_transient( 'last_show_on_front', $last_show_on_front );
-
-		$page_on_front = update_option('page_on_front', $main_site_alertpg_id);
-		$show_on_front = update_option('show_on_front', 'page');
+	// Activate the redirect group and its child redirects
+	if ( $activate == true ) {
+		// Activate the redirection plugin group with ID $main_site_rd_group_id.
+		$main_site_rd_group->enable();
 	}
 	else {
-		$last_page_on_front = get_transient( 'last_page_on_front' );
-		$last_show_on_front = get_transient( 'last_show_on_front' );
-
-		$last_page_on_front = $last_page_on_front ?: '0';
-		$last_show_on_front = $last_show_on_front ?: 'posts';
-
-		$page_on_front = update_option( 'page_on_front', $last_page_on_front );
-		$show_on_front = update_option( 'show_on_front', $last_show_on_front );
+		// Deactivate the redirection plugin group and its child redirects
+		$main_site_rd_group->disable();
 	}
-	if (!$page_on_front) { $errors->add('switchover_update_pof_failed', 'update_option(\'page_on_front\') failed!'); }
-	if (!$show_on_front) { $errors->add('switchover_update_sof_failed', 'update_option(\'show_on_front\') failed!'); }
 
 	// Run a ban on the home page if VDP plugin is activated on Main Site
 	if (is_plugin_active('varnish-dependency-purge/varnish-dependency-purge.php')) {
@@ -258,9 +246,13 @@ function switchout_main_site_homepg($activate=true) {
 
 
 /**
- * Perform a series of checks to make sure the Main Site on this
- * multisite instance exists, has all necessary plugins installed,
- * and has a page with the ID we specify in this site's theme options.
+ * Perform a series of checks to make sure that:
+ * - The main site on this multisite instance exists,
+ * - The alert site has all necessary plugins installed,
+ * - The main site has all necessary plugins installed,
+ * - The main site has a Redirection group saved with the ID specified in this
+ *   theme's theme options,
+ * - The Redirection group on the main site has at least one redirect defined.
  *
  * If everything looks valid, this function returns false.  Otherwise,
  * a WP_Error object is returned with relevant errors.
@@ -270,26 +262,49 @@ function pre_main_site_switchover_errors() {
 
 	// Get the Main Site ID and the ID of the page to switch to set in Theme Options.
 	// If one of these is not set, return now with an error.
-	$main_site_id = intval(get_theme_option('main_site_id'));
-	$main_site_alertpg_id = intval(get_theme_option('main_site_alertpg_id'));
-	if (!$main_site_id) { $errors->add('pre_switchover_no_siteid', 'Main Site ID is not set in Theme Options.'); }
-	if (!$main_site_alertpg_id) { $errors->add('pre_switchover_no_alertpgid', 'Main Site Alert Switchover Page ID is not set in Theme Options.'); }
+	$main_site_id = intval( get_theme_option( 'main_site_id' ) );
+	$main_site_rd_group_id = intval( get_theme_option( 'main_site_rd_group_id' ) );
+	if ( !$main_site_id ) { $errors->add( 'pre_switchover_no_siteid', 'Main Site ID is not set in Theme Options.' ); }
+	if ( !$main_site_rd_group_id ) { $errors->add( 'pre_switchover_no_rd_groupid', 'Main Site Redirection Group ID is not set in Theme Options.' ); }
 
 	// Make sure the site with the given ID exists before switching.
 	// switch_to_blog() will NOT return false if the site with $main_site_id
 	// doesn't exist!
-	$blog_details = get_blog_details($main_site_id);
-	if (!$blog_details) { $errors->add('pre_switchover_invalid_siteid', 'Blog with ID '.$main_site_id.' not found on this multisite instance.'); }
+	$blog_details = get_blog_details( $main_site_id );
+	if ( !$blog_details ) { $errors->add( 'pre_switchover_invalid_siteid', 'Blog with ID ' . $main_site_id . ' not found on this multisite instance.' ); }
 
-	switch_to_blog($main_site_id);
+	// Make sure required plugins are activated on the alert site
+	if ( !is_plugin_active( 'redirection/redirection.php' ) || !class_exists( 'Red_Group' ) ) {
+		$errors->add( 'pre_switchover_deactivated_plugin_alert_rd', 'Redirection plugin not activated on the Alert Site.' );
+	}
 
-	$alertpg = get_post($main_site_alertpg_id);
-	if (!$alertpg) { $errors->add('pre_switchover_invalid_alertpgid', 'Could not find page on Main Site with ID of '.$main_site_alertpg_id.'.'); }
+	switch_to_blog( $main_site_id );
+
+	// Make sure required plugins are activated on the main site
+	if ( !is_plugin_active( 'redirection/redirection.php' ) ) {
+		$errors->add( 'pre_switchover_deactivated_plugin_ms_rd', 'Redirection plugin not activated on the Main Site.' );
+	}
+
+	// Check for a Redirection group with the ID set in theme options
+	$main_site_rd_group = false;
+	if ( class_exists( 'Red_Group' ) ) {
+		$main_site_rd_group = Red_Group::get( $main_site_rd_group_id );
+	}
+	if ( !$main_site_rd_group ) {
+		$errors->add( 'pre_switchover_no_rd_group', 'Main Site Redirection Group with ID ' . $main_site_rd_group_id . ' not found on the Main Site.' );
+	}
+	else {
+		// Check for at least one redirect rule defined in the group set in theme options
+		$main_site_rd_group_count = $main_site_rd_group->get_total_redirects();
+		if ( intval( $main_site_rd_group_count ) < 1 ) {
+			$errors->add( 'pre_switchover_no_rd_group_redirects', 'The Main Site Redirection Group with ID ' . $main_site_rd_group_id . ' does not have at least one redirect rule defined.' );
+		}
+	}
 
 	// Switch back the blog and finish.
 	restore_current_blog();
 
-	if (empty($errors->errors)) {
+	if ( empty( $errors->errors ) ) {
 		return false;
 	}
 	else {
@@ -299,20 +314,21 @@ function pre_main_site_switchover_errors() {
 
 
 /**
- * Determine if the 'Front Page Displays' option on the Main Site
- * is set to display the Main Site Alert Switchover page.
+ * Determine if the Main Site's alert redirects are enabled.
  **/
 function is_main_site_homepg_switched() {
 	$is_switched = false;
 
-	$main_site_id = intval(get_theme_option('main_site_id'));
-	$main_site_alertpg_id = intval(get_theme_option('main_site_alertpg_id'));
+	$main_site_id          = intval( get_theme_option( 'main_site_id' ) );
+	$main_site_rd_group_id = intval( get_theme_option( 'main_site_rd_group_id' ) );
 
-	switch_to_blog($main_site_id);
-	$front_pg_option = get_option('page_on_front');
-	if (intval($front_pg_option) == $main_site_alertpg_id) {
+	switch_to_blog( $main_site_id );
+
+	$main_site_rd_group = Red_Group::get( $main_site_rd_group_id );
+	if ( $main_site_rd_group->is_enabled() ) {
 		$is_switched = true;
 	}
+
 	restore_current_blog();
 
 	return $is_switched;

--- a/functions.php
+++ b/functions.php
@@ -324,9 +324,11 @@ function is_main_site_homepg_switched() {
 
 	switch_to_blog( $main_site_id );
 
-	$main_site_rd_group = Red_Group::get( $main_site_rd_group_id );
-	if ( $main_site_rd_group->is_enabled() ) {
-		$is_switched = true;
+	if ( class_exists( 'Red_Group' ) ) {
+		$main_site_rd_group = Red_Group::get( $main_site_rd_group_id );
+		if ( $main_site_rd_group->is_enabled() ) {
+			$is_switched = true;
+		}
 	}
 
 	restore_current_blog();

--- a/functions.php
+++ b/functions.php
@@ -283,13 +283,8 @@ function pre_main_site_switchover_errors() {
 
 	switch_to_blog($main_site_id);
 
-	if (!is_plugin_active('page-links-to/page-links-to.php')) { $errors->add('pre_switchover_deactivated_plugin_plt', 'Page Links To plugin not activated on the Main Site.'); }
-
 	$alertpg = get_post($main_site_alertpg_id);
 	if (!$alertpg) { $errors->add('pre_switchover_invalid_alertpgid', 'Could not find page on Main Site with ID of '.$main_site_alertpg_id.'.'); }
-
-	$alertpg_redirect = get_post_meta($main_site_alertpg_id, '_links_to');
-	if (empty($alertpg_redirect)) { $errors->add('pre_switchover_missing_redirect', 'No redirect is set on the Main Site Alert Switchover Page.'); }
 
 	// Switch back the blog and finish.
 	restore_current_blog();

--- a/functions/config.php
+++ b/functions/config.php
@@ -135,15 +135,14 @@ Config::$theme_settings = array(
 			'value'       => $theme_options['main_site_id'],
 		)),
 		new TextField(array(
-			'name'        => 'Main Site Alert Switchover Page ID',
-			'id'          => THEME_OPTIONS_NAME.'[main_site_alertpg_id]',
-			'description' => 'ID of the page on the Main Site that should be switched to
-							 when the Text-Only Main Site Switchover is activated. The page
-							 with this ID should redirect to www.ucf.edu/alert using the
-							 Page Links To plugin. This setting is required for managing
-							 Main Site switchovers from this site.',
-			'default'     => '1',
-			'value'       => $theme_options['main_site_alertpg_id'],
+			'name'        => 'Main Site Alert Redirection Group ID',
+			'id'          => THEME_OPTIONS_NAME.'[main_site_rd_group_id]',
+			'description' => 'ID of the Redirection plugin redirect group on the Main Site
+							 that should be enabled when the Text-Only Main Site Switchover
+							 is activated. The group will be disabled upon deactivating the
+							 switchover. This setting is required for managing Main Site
+							 switchovers from this site.',
+			'value'       => $theme_options['main_site_rd_group_id'],
 		)),
 	),
 	'Styles' => array(

--- a/includes/main-site-switchover.php
+++ b/includes/main-site-switchover.php
@@ -6,7 +6,7 @@ define(MAIN_SITE_ID, $theme_options['main_site_id']);
     <?php settings_fields(THEME_OPTIONS_GROUP);?>
 	<div class="container">
 		<h2>Emergency Text-Only Main Site Switchover</h2>
-		
+
 		<?php
 		// Check for any possible configuration errors with the
 		// Main Site before allowing the user to perform activation/
@@ -14,7 +14,7 @@ define(MAIN_SITE_ID, $theme_options['main_site_id']);
 		$errors = pre_main_site_switchover_errors();
 
 		if (!$errors) {
-			if ($_POST['submit-button']) {
+			if ( isset( $_POST['submit-button'] ) ) {
 				if ($_POST['submit-button'] == 'Activate') {
 					$switch = switchout_main_site_homepg();
 					if ($switch) {
@@ -45,7 +45,7 @@ define(MAIN_SITE_ID, $theme_options['main_site_id']);
 
 			$homepg_is_switched = is_main_site_homepg_switched();
 			?>
-			
+
 			<div class="well">
 				<p>Current status: <?=$homepg_is_switched ? '<span class="activated">Activated</span>' : '<span class="deactivated">Deactivated</span>'?></p>
 			</div>
@@ -61,7 +61,7 @@ define(MAIN_SITE_ID, $theme_options['main_site_id']);
 			</p>
 			<p>
 				This action will take effect immediately.  <strong>Do not click the button below unless there
-				is an actual emergency, or you are performing official university emergency response tests.</strong> 
+				is an actual emergency, or you are performing official university emergency response tests.</strong>
 			</p>
 
 			<div class="submit">


### PR DESCRIPTION
Refactors how the main site/alert switchover process works.

## TL;DR:
Main site homepage switchout logic is getting replaced with Redirection plugin redirect group enabling/disabling.

## Overview of the current process:
Currently, the main site homepage switchover works by allowing a UCF Alert site on the same multisite instance as the main site to programmatically switch the active homepage on the main site.  When the switchover is activated, the current homepage will get swapped with a predefined page on the main site with a Page Links To redirect pointing to ucf.edu/alert/.  Whenever the switchover is live, requests for ucf.edu are thus redirected to ucf.edu/alert/.  When the switchover is deactivated, the previous home page is restored, and the redirect to ucf.edu/alert/ stops.

## Why we're changing it:
The Page Links To plugin applies 301 redirects for all redirect rules.  As far as we're aware, this has worked fine up to this point, but during recent testing of the switchover process, I noticed that Chrome was caching the 301 response even after disabling the switchover, and would continue to redirect the main site homepage to the alert site.  Because 301 redirects are assumed to be permanent, Chrome is technically making a safe assumption here.  Regardless, we should be using a temporary redirect anyway, since main site switchovers are, well, temporary.  There's some good information on when to use temporary redirects and what type to use here: https://yoast.com/ask-yoast-use-a-302-or-307-redirect/  Because there's no option to change the type of redirect used with Page Links To, we need to implement an alternative redirect solution.

## What's changing:
To be able to set up 307 temporary redirects via WordPress in a programmatic way, this branch removes the main site homepage switchout logic and replaces it with enabling/disabling of a predefined [Redirection plugin](https://wordpress.org/plugins/redirection/) redirect group on the main site.  We'll store the ID of the desired redirect group in the alert site's theme options, similarly to how we were storing the switchout page ID previously.

The Redirection plugin will be required on **both** the main site and alert site moving forward for this process to work (on the main site for managing the redirect group/rule, and on the alert site so that necessary plugin files are loaded/the `Red_Group` class is accessible for the alert theme).