### PR TITLE
Remove VDP logic

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -197,22 +197,14 @@ function switchout_main_site_homepg( $activate=true ) {
 		$main_site_rd_group->disable();
 	}
 
-	// Run a ban on the home page if VDP plugin is activated on Main Site
-	if (is_plugin_active('varnish-dependency-purge/varnish-dependency-purge.php')) {
-		$ban_url = '/';
-
-		// $vdp variable should already be available by this point,
-		// but create it in case it's not
-		$ms_vdp = new VDP();
-		$nodes = $ms_vdp->parse_varnish_nodes();
-
-		if ($nodes) {
-			foreach ($nodes as $node) {
-				$node->ban($ban_url);
-			}
-		}
-		else {
-			$errors->add('switchover_missing_vdp_nodes', 'VDP plugin is activated on Main Site, but varnish nodes are not set!');
+	// Force an update on the main site homepage to trigger cache updates
+	// if enabled
+	$do_main_site_ban = filter_var( get_theme_option( 'main_site_homepg_switchout_ban' ), FILTER_VALIDATE_BOOLEAN );
+	$main_site_homepg = get_post( intval( get_option( 'page_on_front' ) ) );
+	if ( $do_main_site_ban && $main_site_homepg instanceof WP_Post ) {
+		$main_site_homepg_update = wp_update_post( array( 'ID' => $main_site_homepg->ID ), true );
+		if ( is_wp_error( $main_site_homepg_update ) ) {
+			$errors = $main_site_homepg_update;
 		}
 	}
 

--- a/functions/config.php
+++ b/functions/config.php
@@ -145,6 +145,23 @@ Config::$theme_settings = array(
 			'default'     => '1',
 			'value'       => $theme_options['main_site_alertpg_id'],
 		)),
+		new RadioField(array(
+			'name'        => 'Try to Clear Cache on Main Site Homepage upon Switchover Activation/Deactivation',
+			'id'          => THEME_OPTIONS_NAME.'[main_site_homepg_switchout_ban]',
+			'description' => 'Turn this option on to allow the Main Site\'s homepage to be
+							  updated programmatically when the Main Site Switchover is
+							  activated or deactivated. Doing so should trigger a cache
+							  ban/purge on most cache-related plugins. Note that this will
+							  fail if the Main Site is not configured to display a static
+							  page as the front page (is set to display "latest posts"
+							  in Settings > Reading).',
+			'default' 	  => 1,
+			'choices'     => array(
+				'On'  => 1,
+				'Off' => 0,
+			),
+			'value'       => $theme_options['main_site_homepg_switchout_ban'],
+		)),
 	),
 	'Styles' => array(
 		new RadioField(array(

--- a/includes/main-site-switchover.php
+++ b/includes/main-site-switchover.php
@@ -56,8 +56,8 @@ define(MAIN_SITE_ID, $theme_options['main_site_id']);
 				to its normal home page.
 			</p>
 			<?php
-			$do_ban = filter_var( $theme_options['main_site_homepg_switchout_ban'], FILTER_VALIDATE_BOOLEAN );
-			if ( $do_ban ) :
+			$do_main_site_ban = filter_var( $theme_options['main_site_homepg_switchout_ban'], FILTER_VALIDATE_BOOLEAN );
+			if ( $do_main_site_ban ) :
 			?>
 			<p>
 				Any time this toggle is switched, the home page cache of ucf.edu is removed (banned) to prevent

--- a/includes/main-site-switchover.php
+++ b/includes/main-site-switchover.php
@@ -6,7 +6,7 @@ define(MAIN_SITE_ID, $theme_options['main_site_id']);
     <?php settings_fields(THEME_OPTIONS_GROUP);?>
 	<div class="container">
 		<h2>Emergency Text-Only Main Site Switchover</h2>
-		
+
 		<?php
 		// Check for any possible configuration errors with the
 		// Main Site before allowing the user to perform activation/
@@ -45,7 +45,7 @@ define(MAIN_SITE_ID, $theme_options['main_site_id']);
 
 			$homepg_is_switched = is_main_site_homepg_switched();
 			?>
-			
+
 			<div class="well">
 				<p>Current status: <?=$homepg_is_switched ? '<span class="activated">Activated</span>' : '<span class="deactivated">Deactivated</span>'?></p>
 			</div>
@@ -55,13 +55,18 @@ define(MAIN_SITE_ID, $theme_options['main_site_id']);
 				www.ucf.edu will redirect to www.ucf.edu/alert.  Deactivating this switch will return ucf.edu
 				to its normal home page.
 			</p>
+			<?php
+			$do_ban = filter_var( $theme_options['main_site_homepg_switchout_ban'], FILTER_VALIDATE_BOOLEAN );
+			if ( $do_ban ) :
+			?>
 			<p>
 				Any time this toggle is switched, the home page cache of ucf.edu is removed (banned) to prevent
 				stale content from displaying and to ensure the switchover takes effect immediately.
 			</p>
+			<?php endif; ?>
 			<p>
 				This action will take effect immediately.  <strong>Do not click the button below unless there
-				is an actual emergency, or you are performing official university emergency response tests.</strong> 
+				is an actual emergency, or you are performing official university emergency response tests.</strong>
 			</p>
 
 			<div class="submit">


### PR DESCRIPTION
Replaces VDP-specific banning logic with a simple `wp_post_update()` call, which will trigger post update actions that most cache plugins should utilize to handle bans and purges.  The homepage update trigger can be disabled via theme options if need be.