### PR TITLE
Moved CORS header adjustment for RSS alert feeds

### DIFF
--- a/feeds/feed-alert-rss2.php
+++ b/feeds/feed-alert-rss2.php
@@ -6,6 +6,7 @@
  */
 
 header('Content-Type: ' . feed_content_type('rss-http') . '; charset=' . get_option('blog_charset'), true);
+header( 'Access-Control-Allow-Origin: *' );
 $more = 1;
 
 echo '<?xml version="1.0" encoding="'.get_option('blog_charset').'"?'.'>'; ?>

--- a/functions.php
+++ b/functions.php
@@ -327,14 +327,3 @@ function is_main_site_homepg_switched() {
 
 	return $is_switched;
 }
-
-
-/**
- * Add CORS support for the RSS feed.
- **/
-function add_header_origin() {
-	if ( is_feed() ) {
-		header( 'Access-Control-Allow-Origin: *' );
-	}
-}
-add_action( 'pre_get_posts', 'add_header_origin' );


### PR DESCRIPTION
Moved CORS header adjustment from `pre_get_posts` hook to custom RSS feed to avoid already-sent header warnings.