### PR TITLE
Arialabel alert

### DIFF
--- a/header.php
+++ b/header.php
@@ -41,6 +41,6 @@
 	</head>
 	<body>
 		<div class="container">
-			<div class="row"  id="header">
+			<header class="row" id="header" aria-label="main title">
 				<h1 class="span10"><a href="<?php echo bloginfo('url'); ?>">UCF Alert</a></h1>
-			</div>
+			</header>

--- a/header.php
+++ b/header.php
@@ -41,6 +41,6 @@
 	</head>
 	<body>
 		<div class="container">
-			<header class="row" id="header" aria-label="main title">
+			<header class="row" id="header" aria-label="Main title">
 				<h1 class="span10"><a href="<?php echo bloginfo('url'); ?>">UCF Alert</a></h1>
 			</header>

--- a/index.php
+++ b/index.php
@@ -1,5 +1,5 @@
 <?php get_header(); the_post();?>
-<div class="row page-content">
+<main class="row page-content" aria-label="Main content">
 	<div class="span8">
 		<?php
 			$alerts = get_posts(array(
@@ -58,5 +58,5 @@
 			?>
 		</div>
 	</div>
-</div>
+</main>
 <?php get_footer(); ?>


### PR DESCRIPTION
# Issue 
Text not included in an ARIA landmark
WAI-ARIA authoring practices
All perceivable text content should be included in an [ARIA landmark](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/).

Perceivable text content refers to text that can be perceived by users of assistive technology — some of which may be invisible to sighted users.

# Why it is an Issue? 

Landmark roles provide information about page structure, and can help assistive technology users with in-page navigation. Having text outside of the landmarks will make it more difficult to navigate to for some visitors.

There are 8 standard [landmark roles](https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/#landmarkroles) defined in WAI-ARIA. Page sections may be given a generic region role if other ARIA landmark roles aren't appropriate.

# Solution 

- Ensure all perceivable text is included in an ARIA landmark.
- The "header" & "main" tags plus adding aria-label attribute automatically communicates that a section has a role of header and main respectively.