### PR TITLE
Added properties to the abstract class for fields

### DIFF
--- a/functions/base.php
+++ b/functions/base.php
@@ -127,6 +127,12 @@ class Config{
  * @author Jared Lang
  **/
 abstract class Field{
+	public $name;
+	public $id;
+	public $value;
+	public $description;
+	public $default;
+
 	protected function check_for_default(){
 		if ($this->value === null){
 			$this->value = $this->default;
@@ -183,6 +189,8 @@ abstract class Field{
  * @author Jared Lang
  **/
 abstract class ChoicesField extends Field{
+	public $choices;
+
 	function __construct($attr){
 		$this->choices = @$attr['choices'];
 		parent::__construct($attr);


### PR DESCRIPTION
- Fixes #22 
- You're not able to "dynamically" create properties as of PHP 8, so public properties need to be declared in the class space before assigning a value to them.
- The deprecation notices were being thrown on the child classes, but by adding the property to the parent/abstract classes, then inherit to the children.